### PR TITLE
Bugfix for user registration of multiple identities

### DIFF
--- a/minid_server/api/views.py
+++ b/minid_server/api/views.py
@@ -317,11 +317,7 @@ def register_user():
         abort(400)
     elif globus_auth_header:
         validate_globus_user(email, globus_auth_header)
-        # No need to set a code if the user is using Globus
-        code = ''
-    else:
-        code = str(uuid.uuid4())
-    print ("querying %s" %code)
+    code = str(uuid.uuid4())
     user = Miniduser.query.filter_by(email=email).first()
     print("after")
     if user is None: 


### PR DESCRIPTION
When registering an identity, the minid server can fail with a 'not
unique' error when used with Globus. This is because the minid code
is marked as 'unique' on the DB schema and isn't saved when Globus
is used. A better solution would be removing the unique constraint,
but saving the code and simply not emailing the user when they use
Globus is an equivalent hack that won't require a db migration.